### PR TITLE
added nose arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [nosetests]
-verbosity=1
+verbosity=2
+with-spec=1
+spec-color=1
+with-coverage=1
+cover-erase=1
+cover-package=service
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
This pull request adds the required configuration in `setup.cfg` to support test-driven development using `nosetests` with:

- Verbose output
- Spec-style display
- Colored output
- Test coverage enabled by default

This change supports the user story: **Set up the development environment** (technical debt).

All tests run successfully, and the setup is now ready for further TDD work in Sprint 1.