### PR TITLE
Implementation of the GET /accounts endpoint to list accounts

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -60,8 +60,17 @@ def create_accounts():
 ######################################################################
 # LIST ALL ACCOUNTS
 ######################################################################
+@app.route("/accounts", methods=["GET"])
+def list_accounts():
+    """
+    List all Accounts
+    This endpoint returns a list of all accounts
+    """
+    app.logger.info("Request to list all Accounts")
+    accounts = Account.all()
+    results = [account.serialize() for account in accounts]
+    return jsonify(results), status.HTTP_200_OK
 
-# ... place you code here to LIST accounts ...
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -124,3 +124,12 @@ class TestAccountService(TestCase):
         self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 
     # ADD YOUR TEST CASES HERE ...
+
+    def test_list_all_accounts(self):
+        """It should List all Accounts"""
+        self._create_accounts(3)  # Crea 3 cuentas de prueba
+        resp = self.client.get(BASE_URL)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 3)
+


### PR DESCRIPTION
This pull request implements the GET /accounts endpoint to retrieve a list of all customer accounts.

Calls Account.all() to fetch all accounts from the database.

Returns the list serialized as JSON.

Responds with status code 200 OK, even when the list is empty ([]).

Testing
Added unit test test_list_all_accounts() in test_routes.py.

Verified that the endpoint returns the correct status and data structure.

All tests pass and code coverage remains above 95%.