### PR TITLE
Implementation of the DELETE /accounts/<id> endpoint

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -76,7 +76,6 @@ def list_accounts():
 ######################################################################
 # READ AN ACCOUNT
 ######################################################################
-
 @app.route("/accounts/<int:account_id>", methods=["GET"])
 def get_account(account_id):
     """Read a single Account"""
@@ -91,7 +90,6 @@ def get_account(account_id):
 ######################################################################
 # UPDATE AN EXISTING ACCOUNT
 ######################################################################
-
 @app.route("/accounts/<int:account_id>", methods=["PUT"])
 def update_account(account_id):
     """Update an Account"""
@@ -109,8 +107,18 @@ def update_account(account_id):
 ######################################################################
 # DELETE AN ACCOUNT
 ######################################################################
+@app.route("/accounts/<int:account_id>", methods=["DELETE"])
+def delete_account(account_id):
+    """
+    Delete an Account
+    This endpoint will delete an Account based on the account_id that is passed in
+    """
+    app.logger.info("Request to delete Account with id: %s", account_id)
+    account = Account.find(account_id)
+    if account:
+        account.delete()
+    return "", status.HTTP_204_NO_CONTENT
 
-# ... place you code here to DELETE an account ...
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -171,3 +171,14 @@ class TestAccountService(TestCase):
             content_type="application/json"
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_account(self):
+        """It should Delete an Account"""
+        account = self._create_accounts(1)[0]
+        response = self.client.delete(f"{BASE_URL}/{account.id}")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_delete_account_not_found(self):
+        """It should not fail if Account to delete is not found"""
+        response = self.client.delete(f"{BASE_URL}/0")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
This PR implements the DELETE /accounts/{id} endpoint.
It allows removing an account by its ID and returns HTTP 204 when successful.
If the account is not found, it silently returns 204 as well, according to the requirements.