### PR TITLE
Add test for method not allowed error (HTTP 405)

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -182,3 +182,8 @@ class TestAccountService(TestCase):
         """It should not fail if Account to delete is not found"""
         response = self.client.delete(f"{BASE_URL}/0")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_method_not_allowed(self):
+        """It should not allow an illegal method call"""
+        resp = self.client.delete(BASE_URL)
+        self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)


### PR DESCRIPTION
This update adds a test case to ensure the service returns the correct HTTP 405 status code when a disallowed HTTP method is used on the /accounts endpoint.
