### PR TITLE
Add Dockerfile to containerize the microservice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use Python 3.9 slim as the base image
+FROM python:3.9-slim
+
+# Create working folder and install dependencies
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the application contents
+COPY service/ ./service/
+
+# Switch to a non-root user
+RUN useradd --uid 1000 theia && chown -R theia /app
+USER theia
+
+# Run the service
+EXPOSE 8080
+CMD ["gunicorn", "--bind=0.0.0.0:8080", "--log-level=info", "service:app"]


### PR DESCRIPTION
This pull request adds a Dockerfile to the project to enable containerization of the microservice.
Key changes include:

Base image set to python:3.9-slim

Installation of Python dependencies using requirements.txt

Copying of the service package into the image

Configuration of a non-root user (theia)

Exposure of port 8080 and use of gunicorn as the WSGI server

This Dockerfile will allow the microservice to be built and run as a Docker container, which is a necessary step for deployment in a containerized environment like Kubernetes or OpenShift.

