### PR TITLE
Add Kubernetes support

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: accounts
+  name: accounts
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: accounts
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: accounts
+    spec:
+      containers:
+        - image: us.icr.io/sn-labs-danygv/accounts:1
+          name: accounts
+          resources: {}
+          env:
+            - name: DATABASE_HOST
+              value: postgresql
+            - name: DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: database-name
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: database-password
+            - name: DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: database-user
+status: {}

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: accounts
+  name: accounts
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: accounts
+  type: NodePort
+status:
+  loadBalancer: {}


### PR DESCRIPTION
This pull request adds Kubernetes support for the accounts microservice. 

It includes:
- A deployment manifest (deployment.yaml) configured with environment variables from the PostgreSQL secret
- A service manifest (service.yaml) exposing the application on port 8080

These changes allow the microservice to be deployed and accessed within the OpenShift environment.